### PR TITLE
handler 테스트 추가

### DIFF
--- a/src/auth/user.handler.spec.ts
+++ b/src/auth/user.handler.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserManager, UserReader } from './user.handler';
+import { UserEntity } from './struct/user.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+describe('UserManager and UserReader', () => {
+  let userRepository: Repository<UserEntity>;
+  let userManager: UserManager;
+  let userReader: UserReader;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserManager,
+        UserReader,
+        {
+          provide: getRepositoryToken(UserEntity),
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    userRepository = module.get<Repository<UserEntity>>(
+      getRepositoryToken(UserEntity),
+    );
+    userManager = module.get<UserManager>(UserManager);
+    userReader = module.get<UserReader>(UserReader);
+  });
+
+  const userData = { email: 'test@example.com', password: 'test1234' };
+  const createdUserData = { ...userData, id: 1, balance: 0 };
+
+  it('shuld create an user', async () => {
+    const createSpy = jest
+      .spyOn(userRepository, 'create')
+      .mockReturnValue(userData as UserEntity);
+
+    const result = await userManager.create(userData);
+
+    expect(createSpy).toHaveBeenCalledWith(userData);
+    expect(result).toEqual(userData);
+  });
+
+  it('should create and save a user', async () => {
+    const saveSpy = jest
+      .spyOn(userRepository, 'save')
+      .mockResolvedValue(createdUserData as UserEntity);
+
+    const result = await userManager.save(userData);
+
+    expect(saveSpy).toHaveBeenCalledWith(userData);
+    expect(result).toEqual(createdUserData);
+  });
+
+  it('should find user by email', async () => {
+    const email = 'test@example.com';
+
+    const findSpy = jest
+      .spyOn(userRepository, 'findOneBy')
+      .mockResolvedValue(createdUserData as UserEntity);
+
+    const result = await userReader.findOneByEmail(email);
+
+    expect(findSpy).toHaveBeenCalledWith({ email });
+    expect(result).toEqual(createdUserData);
+  });
+});

--- a/src/date/date.handler.spec.ts
+++ b/src/date/date.handler.spec.ts
@@ -46,6 +46,7 @@ describe('DateReader', () => {
       },
     });
 
-    expect(result).toEqual(mockDates as DateEntity[]);
+    const expectedDates = mockDates.map((date) => date.date);
+    expect(result).toEqual(expectedDates as string[]);
   });
 });

--- a/src/date/date.handler.spec.ts
+++ b/src/date/date.handler.spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DateReader } from './date.handler';
+import { DateEntity } from './struct/date.entity';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+describe('DateReader', () => {
+  let dateReader: DateReader;
+  let dateRepository: Repository<DateEntity>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DateReader,
+        {
+          provide: getRepositoryToken(DateEntity), // Replace getRepositoryToken with your actual function to get repository token
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    dateReader = module.get<DateReader>(DateReader);
+    dateRepository = module.get<Repository<DateEntity>>(
+      getRepositoryToken(DateEntity),
+    );
+  });
+
+  it('should return available dates', async () => {
+    const mockDates: Partial<DateEntity>[] = [{ id: 1, date: '2024-01-01' }];
+
+    const findSpy = jest
+      .spyOn(dateRepository, 'find')
+      .mockResolvedValue(mockDates as DateEntity[]);
+
+    const result = await dateReader.getAvailableDates();
+
+    expect(findSpy).toHaveBeenCalledWith({
+      relations: ['seatAvailability'],
+      where: {
+        seatAvailability: {
+          isAvailable: true,
+        },
+      },
+      order: {
+        date: 'ASC',
+      },
+    });
+
+    expect(result).toEqual(mockDates as DateEntity[]);
+  });
+});

--- a/src/date/date.handler.ts
+++ b/src/date/date.handler.ts
@@ -2,20 +2,19 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { DateEntity } from './struct/date.entity';
-import { Date } from './struct/date.domain';
 
-interface Query<T> {
-  getAvailableDates(): Promise<T[]>;
+interface Query {
+  getAvailableDates(): Promise<string[]>;
 }
 
-export class DateReader implements Query<Date> {
+export class DateReader implements Query {
   constructor(
     @InjectRepository(DateEntity)
     private readonly dateRepository: Repository<DateEntity>,
   ) {}
 
-  async getAvailableDates(): Promise<Date[]> {
-    return await this.dateRepository.find({
+  async getAvailableDates(): Promise<string[]> {
+    const dates = await this.dateRepository.find({
       relations: ['seatAvailability'],
       where: {
         seatAvailability: {
@@ -26,5 +25,7 @@ export class DateReader implements Query<Date> {
         date: 'ASC',
       },
     });
+
+    return dates.map((date) => date.date);
   }
 }

--- a/src/date/date.service.spec.ts
+++ b/src/date/date.service.spec.ts
@@ -4,19 +4,38 @@ import { DateReader } from './date.handler';
 
 describe('DateService', () => {
   let service: DateService;
+  let reader: DateReader;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        { provide: DateService, useValue: jest.fn() },
-        { provide: DateReader, useValue: jest.fn() },
+        DateService,
+        {
+          provide: DateReader,
+          useValue: {
+            getAvailableDates: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<DateService>(DateService);
+    reader = module.get<DateReader>(DateReader);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should get all availble dates', async () => {
+    const dates = ['2024-01-01', '2024-01-02'];
+    const getSpy = jest
+      .spyOn(reader, 'getAvailableDates')
+      .mockResolvedValue(dates);
+
+    const result = await service.getAvailableDates();
+
+    expect(result).toEqual(dates);
+    expect(getSpy).toHaveBeenCalledWith();
   });
 });

--- a/src/date/date.service.ts
+++ b/src/date/date.service.ts
@@ -5,9 +5,7 @@ import { DateReader } from './date.handler';
 export class DateService {
   constructor(private dateReader: DateReader) {}
 
-  async getAvailableDates(): Promise<string[]> {
-    const dates = await this.dateReader.getAvailableDates();
-
-    return dates.map((date) => date.date);
+  getAvailableDates(): Promise<string[]> {
+    return this.dateReader.getAvailableDates();
   }
 }

--- a/src/payment/payment.handler.spec.ts
+++ b/src/payment/payment.handler.spec.ts
@@ -26,15 +26,15 @@ describe('PaymentManager', () => {
     );
   });
 
-  it('should create a payment', async () => {
-    const mockPayment = {
-      userId: 1,
-      amount: 10000,
-      paymentDate: '2024-01-01',
-      status: PAYMENT_STATUS.UNPAID,
-      reservationId: 1,
-    };
+  const mockPayment = {
+    userId: 1,
+    amount: 10000,
+    paymentDate: '2024-01-01',
+    status: PAYMENT_STATUS.UNPAID,
+    reservationId: 1,
+  };
 
+  it('should create a payment', async () => {
     const createSpy = jest
       .spyOn(paymentRepository, 'create')
       .mockReturnValue(mockPayment as PaymentEntity);
@@ -46,14 +46,6 @@ describe('PaymentManager', () => {
   });
 
   it('should save a payment', async () => {
-    const mockPayment = {
-      userId: 1,
-      amount: 10000,
-      paymentDate: '2024-01-01',
-      status: PAYMENT_STATUS.UNPAID,
-      reservationId: 1,
-    };
-
     const mockPaymentWithId = {
       ...mockPayment,
       id: 1,

--- a/src/payment/payment.handler.spec.ts
+++ b/src/payment/payment.handler.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PaymentManager } from './payment.handler';
+import { PaymentEntity } from './payment.entity';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PAYMENT_STATUS } from 'src/common/types/reservation';
+
+describe('PaymentManager', () => {
+  let paymentManager: PaymentManager;
+  let paymentRepository: Repository<PaymentEntity>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentManager,
+        {
+          provide: getRepositoryToken(PaymentEntity),
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    paymentManager = module.get<PaymentManager>(PaymentManager);
+    paymentRepository = module.get<Repository<PaymentEntity>>(
+      getRepositoryToken(PaymentEntity),
+    );
+  });
+
+  it('should create a payment', async () => {
+    const mockPayment = {
+      userId: 1,
+      amount: 10000,
+      paymentDate: '2024-01-01',
+      status: PAYMENT_STATUS.UNPAID,
+      reservationId: 1,
+    };
+
+    const createSpy = jest
+      .spyOn(paymentRepository, 'create')
+      .mockReturnValue(mockPayment as PaymentEntity);
+
+    const result = await paymentManager.create(mockPayment as PaymentEntity);
+
+    expect(createSpy).toHaveBeenCalledWith(mockPayment);
+    expect(result).toEqual(mockPayment);
+  });
+
+  it('should save a payment', async () => {
+    const mockPayment = {
+      userId: 1,
+      amount: 10000,
+      paymentDate: '2024-01-01',
+      status: PAYMENT_STATUS.UNPAID,
+      reservationId: 1,
+    };
+
+    const mockPaymentWithId = {
+      ...mockPayment,
+      id: 1,
+    };
+
+    const saveSpy = jest
+      .spyOn(paymentRepository, 'save')
+      .mockResolvedValue(mockPaymentWithId as PaymentEntity);
+
+    const result = await paymentManager.save(mockPayment as PaymentEntity);
+
+    expect(saveSpy).toHaveBeenCalledWith(mockPayment);
+    expect(result).toEqual(mockPaymentWithId);
+  });
+});

--- a/src/reservation/reservation.handler.spec.ts
+++ b/src/reservation/reservation.handler.spec.ts
@@ -5,15 +5,6 @@ import { ReservationManager, ReservationReader } from './reservation.handler';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { PAYMENT_STATUS } from 'src/common/types/reservation';
 
-const fakeReservation = {
-  id: 1,
-  userId: 1,
-  date: '2024-01-01',
-  seatNumber: 1,
-  isExpired: false,
-  paymentStatus: PAYMENT_STATUS.UNPAID,
-};
-
 describe('ReservationManager and ReservationReader', () => {
   let reservationManager: ReservationManager;
   let reservationReader: ReservationReader;
@@ -26,11 +17,7 @@ describe('ReservationManager and ReservationReader', () => {
         ReservationReader,
         {
           provide: getRepositoryToken(ReservationEntity),
-          useValue: {
-            create: jest.fn(),
-            save: jest.fn(),
-            findOne: jest.fn(),
-          },
+          useClass: Repository,
         },
       ],
     }).compile();
@@ -42,14 +29,23 @@ describe('ReservationManager and ReservationReader', () => {
     );
   });
 
+  const fakeReservation = {
+    id: 1,
+    userId: 1,
+    date: '2024-01-01',
+    seatNumber: 1,
+    isExpired: false,
+    paymentStatus: PAYMENT_STATUS.UNPAID,
+  };
+
   it('should create a reservation', () => {
-    jest
+    const createSpy = jest
       .spyOn(reservationRepository, 'create')
       .mockReturnValue(fakeReservation as ReservationEntity);
 
     const result = reservationManager.create(fakeReservation);
 
-    expect(reservationRepository.create).toHaveBeenCalledWith(fakeReservation);
+    expect(createSpy).toHaveBeenCalledWith(fakeReservation);
     expect(result).toEqual(fakeReservation);
   });
 
@@ -59,26 +55,26 @@ describe('ReservationManager and ReservationReader', () => {
       paymentStatus: PAYMENT_STATUS.PAID,
     };
 
-    jest
+    const saveSpy = jest
       .spyOn(reservationRepository, 'save')
       .mockResolvedValue(updatedReservation as ReservationEntity);
 
     const result = await reservationManager.save(updatedReservation);
 
-    expect(reservationRepository.save).toHaveBeenCalledWith(updatedReservation);
+    expect(saveSpy).toHaveBeenCalledWith(updatedReservation);
     expect(result).toEqual(updatedReservation);
   });
 
   it('should find a reservation', async () => {
     const partialReservation = { id: 1 };
 
-    jest
+    const findSpy = jest
       .spyOn(reservationRepository, 'findOne')
       .mockResolvedValue(fakeReservation as ReservationEntity);
 
     const result = await reservationReader.findOne(partialReservation);
 
-    expect(reservationRepository.findOne).toHaveBeenCalledWith({
+    expect(findSpy).toHaveBeenCalledWith({
       where: partialReservation,
     });
     expect(result).toEqual(fakeReservation);

--- a/src/reservation/reservation.service.spec.ts
+++ b/src/reservation/reservation.service.spec.ts
@@ -56,6 +56,10 @@ describe('ReservationService', () => {
     seatReader = module.get<SeatReader>(SeatReader);
   });
 
+  it('should be defined', () => {
+    expect(reservationService).toBeDefined();
+  });
+
   it('should throw BadRequestException if there is no seat', async () => {
     const wrongRequestReservationDto = {
       seatNumber: 0,

--- a/src/reservation/reservation.service.spec.ts
+++ b/src/reservation/reservation.service.spec.ts
@@ -1,22 +1,112 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
 import { ReservationService } from './reservation.service';
-import { SeatService } from 'src/seat/seat.service';
+import { ReservationManager, ReservationReader } from './reservation.handler';
+import { RequestReservationDto } from './dto/request-reservation.dto';
+import { SeatManager, SeatReader } from 'src/seat/seat.handler';
+import { Seat } from 'src/seat/struct/seat.domain';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 
 describe('ReservationService', () => {
-  let service: ReservationService;
+  let reservationService: ReservationService;
+  let seatReader: SeatReader;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        { provide: ReservationService, useValue: jest.fn() },
-        { provide: SeatService, useValue: jest.fn() },
+        ReservationService,
+        {
+          provide: ReservationManager,
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: ReservationReader,
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: SeatManager,
+          useValue: {
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: SeatReader,
+          useValue: {
+            getSeat: jest.fn(),
+          },
+        },
+        {
+          provide: DataSource,
+          useValue: {
+            createQueryRunner: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
-    service = module.get<ReservationService>(ReservationService);
+    reservationService = module.get<ReservationService>(ReservationService);
+    seatReader = module.get<SeatReader>(SeatReader);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('should throw BadRequestException if there is no seat', async () => {
+    const wrongRequestReservationDto = {
+      seatNumber: 0,
+      date: '2024-01-01',
+    };
+    const getSeatSpy = jest
+      .spyOn(seatReader, 'getSeat')
+      .mockResolvedValue(undefined);
+
+    await expect(
+      reservationService.requestReservation({
+        requestReservationDto: wrongRequestReservationDto,
+        userId: 1,
+      }),
+    ).rejects.toThrow(new BadRequestException('There is no seat'));
+
+    expect(getSeatSpy).toHaveBeenCalledWith({
+      seatNumber: wrongRequestReservationDto.seatNumber,
+      dateAvailability: { date: wrongRequestReservationDto.date },
+    });
+  });
+
+  it('should throw InternalServerErrorException if seat is not available', async () => {
+    const requestReservationDto: RequestReservationDto = {
+      seatNumber: 1,
+      date: '2024-01-01',
+    };
+
+    const seat: Seat = {
+      id: 1,
+      userId: 1,
+      seatNumber: 1,
+      isAvailable: false,
+    };
+
+    const getSeatSpy = jest
+      .spyOn(seatReader, 'getSeat')
+      .mockResolvedValue(seat);
+
+    await expect(
+      reservationService.requestReservation({
+        requestReservationDto,
+        userId: 1,
+      }),
+    ).rejects.toThrow(
+      new InternalServerErrorException('Seat is already reserved'),
+    );
+
+    expect(getSeatSpy).toHaveBeenCalledWith({
+      seatNumber: requestReservationDto.seatNumber,
+      dateAvailability: { date: requestReservationDto.date },
+    });
   });
 });

--- a/src/seat/seat.handler.spec.ts
+++ b/src/seat/seat.handler.spec.ts
@@ -1,0 +1,98 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SeatReader, SeatManager } from './seat.handler';
+import { Repository } from 'typeorm';
+import { SeatEntity } from './struct/seat.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+describe('SeatReader and SeatManager', () => {
+  let seatReader: SeatReader;
+  let seatManager: SeatManager;
+  let seatRepository: Repository<SeatEntity>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SeatReader,
+        SeatManager,
+        {
+          provide: getRepositoryToken(SeatEntity),
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    seatReader = module.get<SeatReader>(SeatReader);
+    seatManager = module.get<SeatManager>(SeatManager);
+    seatRepository = module.get<Repository<SeatEntity>>(
+      getRepositoryToken(SeatEntity),
+    );
+  });
+
+  const mockSeatInfo = {
+    seatNumber: 1,
+    dateAvailability: { date: '2024-01-01' },
+  };
+  const mockSeat = {
+    id: 1,
+    seatNumber: 1,
+    userId: null,
+    isAvailable: true,
+  };
+
+  it('should find a seat by seatInfo', async () => {
+    const findSpy = jest
+      .spyOn(seatRepository, 'findOne')
+      .mockResolvedValue(mockSeat as SeatEntity);
+
+    const result = await seatReader.getSeat(mockSeatInfo);
+
+    expect(findSpy).toHaveBeenCalledWith({
+      where: mockSeatInfo,
+    });
+    expect(result).toEqual(mockSeat);
+  });
+
+  it('should find available seats by date', async () => {
+    const mockDate = '2024-01-01';
+    const mockAvailableSeats: Partial<SeatEntity>[] = [mockSeat];
+
+    const findSpy = jest
+      .spyOn(seatRepository, 'find')
+      .mockResolvedValue(mockAvailableSeats as SeatEntity[]);
+
+    const result = await seatReader.getAvailableSeatByDate(mockDate);
+
+    expect(findSpy).toHaveBeenCalledWith({
+      relations: ['dateAvailability'],
+      where: {
+        dateAvailability: {
+          date: mockDate,
+        },
+        isAvailable: true,
+      },
+      order: {
+        seatNumber: 'ASC',
+      },
+    });
+
+    const expectedSeat = mockAvailableSeats.map((seat) => seat.seatNumber);
+    expect(result).toEqual(expectedSeat as number[]);
+  });
+
+  it('should save a seat', async () => {
+    const mockSavedSeat = {
+      ...mockSeat,
+      userId: 1,
+      isAvailable: false,
+    };
+
+    const saveSpy = jest
+      .spyOn(seatRepository, 'save')
+      .mockResolvedValue(mockSavedSeat as SeatEntity);
+
+    const result = await seatManager.save(mockSeat as SeatEntity);
+
+    expect(saveSpy).toHaveBeenCalledWith(mockSeat);
+    expect(result).toEqual(mockSavedSeat);
+  });
+});

--- a/src/seat/seat.handler.ts
+++ b/src/seat/seat.handler.ts
@@ -5,8 +5,8 @@ import { SeatEntity } from './struct/seat.entity';
 import { Seat } from './struct/seat.domain';
 
 interface Query<T> {
-  getAvailableSeatByDate(date: string): Promise<T[]>;
   getSeat(seatInfo: DeepPartial<T>): Promise<T>;
+  getAvailableSeatByDate(date: string): Promise<number[]>;
 }
 
 export class SeatReader implements Query<Seat> {
@@ -19,8 +19,8 @@ export class SeatReader implements Query<Seat> {
     return this.seatRepository.findOne({ where: seatInfo });
   }
 
-  getAvailableSeatByDate(date: string): Promise<Seat[]> {
-    return this.seatRepository.find({
+  async getAvailableSeatByDate(date: string): Promise<number[]> {
+    const seats = await this.seatRepository.find({
       relations: ['dateAvailability'],
       where: {
         dateAvailability: {
@@ -32,6 +32,8 @@ export class SeatReader implements Query<Seat> {
         seatNumber: 'ASC',
       },
     });
+
+    return seats.map((seat) => seat.seatNumber);
   }
 }
 

--- a/src/seat/seat.service.spec.ts
+++ b/src/seat/seat.service.spec.ts
@@ -1,18 +1,43 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SeatService } from './seat.service';
+import { SeatReader } from './seat.handler';
 
 describe('SeatService', () => {
   let service: SeatService;
+  let reader: SeatReader;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [{ provide: SeatService, useValue: jest.fn() }],
+      providers: [
+        SeatService,
+        {
+          provide: SeatReader,
+          useValue: {
+            getAvailableSeatByDate: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<SeatService>(SeatService);
+    reader = module.get<SeatReader>(SeatReader);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should get available seat by date correctly', async () => {
+    const date = '2024-01-01';
+    const seats = [1, 2, 3, 4, 5];
+
+    const getAvailableSeatSpy = jest
+      .spyOn(reader, 'getAvailableSeatByDate')
+      .mockResolvedValue(seats);
+
+    const result = await service.getAvailableSeatsByDate(date);
+
+    expect(result).toEqual(seats);
+    expect(getAvailableSeatSpy).toHaveBeenCalledWith(date);
   });
 });

--- a/src/seat/seat.service.ts
+++ b/src/seat/seat.service.ts
@@ -5,9 +5,7 @@ import { SeatReader } from './seat.handler';
 export class SeatService {
   constructor(private seatReader: SeatReader) {}
 
-  async getAvailableSeatsByDate(date: string): Promise<number[]> {
-    const seats = await this.seatReader.getAvailableSeatByDate(date);
-
-    return seats.map((seat) => seat.seatNumber);
+  getAvailableSeatsByDate(date: string): Promise<number[]> {
+    return this.seatReader.getAvailableSeatByDate(date);
   }
 }


### PR DESCRIPTION
handler에 테스트 코드를 추가했습니다.

지난주에 허재 코치님이 멘토링해주신 것 중에
컴포넌트 레이어에서 repository에서 얻은 값에 대한 데이터 포맷 변경도 해당 레이어에서 일어나는게 좋다고해서 그부분도 약간 수정했습니다.
(date.handler, seat.handler) 
사실 왜였는진 이유가 기억나진 않네요 ㅎㅎ

```
// 좌석 정보를 가져오는 명세
export interface SeatRepository {
	getPossibleSeats(targetDate: Date): Promise<List<Seat>>
}
export const SeatRepositoryToken = "RepoSeat"
// 
class SeatRepositoryImpl implements SeatRepository {
	constructor(
		@Inject()
		private seatRepository: Repository<SeatEntity> // TypeOrm Repository 객체
	) { }
	
	async getpossibleSeats(targetDate: Date): Promise<List<Seat>> {
		return seatRepository.find~~().map(() => this.toSeat())
		// 변환해서 올려준다.
	}
}
```