### PR TITLE
feat: replace logger

### DIFF
--- a/src/common/filter/exception.filter.ts
+++ b/src/common/filter/exception.filter.ts
@@ -4,10 +4,10 @@ import {
   ExceptionFilter as NestExceptionFilter,
   HttpException,
   InternalServerErrorException,
-  Logger,
   LoggerService,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import Logger from '../logger/logger';
 
 @Catch()
 export class ExceptionFilter implements NestExceptionFilter {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,10 @@ import { AppModule } from './app.module';
 import swaggerConfig from './common/config/swagger.config';
 import { ConfigService } from '@nestjs/config';
 import { ValidationPipe } from '@nestjs/common';
-import Logger from './common/logger/logger';
 import { ExceptionFilter } from './common/filter/exception.filter';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {
-    logger: new Logger('common'),
-  });
+  const app = await NestFactory.create(AppModule);
 
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
   app.setGlobalPrefix('api');


### PR DESCRIPTION
저랑 병현님이랑 테스트하는데 슬랙에서 무한 메세지가 오길래 찾아봤더니

이게 main.ts에서 글로벌로 걸어주는 로그가 생각보다 많은 로그를 발생시켜서
한번 에러 일으켰더니 너무 많은 메세지가 슬랙으로 계속 보내지더라구요.

그리고 main.ts에 있던건 클라우드와치로 쏘는 로거라서 일단 제 AWS 요금을 지키기위해 없앴구요.
exception에 있던 로거는 nestjs에 있던 기본 로거였어서 그걸 클라우드와치를 쏴주는 로거로 교체했습니다.


