### PR TITLE
feat: change infra

### DIFF
--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy-ecr:
     name: Deploy to ECR
-    runs-on: [self-hosted, concert-tdd-runner]
+    runs-on: ubuntu-latest
     environment: production
 
     steps:

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -65,7 +65,12 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          # Output the image URL to the GitHub Actions environment
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
+
+          # Set the image URL as an output for other jobs
+          echo "IMAGE_URL=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
   deploy-ec2:
     needs: deploy-ecr
@@ -87,7 +92,7 @@ jobs:
       - name: Pull image from Amazon ECR and restart container
         run: |
           # Get the image URL from the deploy-ecr job's outputs
-          IMAGE_URL=${{ needs.deploy-ecr.outputs.image }}
+          IMAGE_URL=${{ env.IMAGE_URL }}
 
           docker pull $IMAGE_URL
           docker stop concert-tdd && docker rm concert-tdd

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -65,13 +65,11 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-          # Output the image URL to the GitHub Actions environment
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
+          # Save the image URL to the GitHub Actions state file
+          echo "IMAGE_URL=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_STATE
 
           # Set the image URL as an output for other jobs
-          echo "IMAGE_URL=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
+          echo "IMAGE_URL=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
   deploy-ec2:
     needs: deploy-ecr
     name: Deploy to EC2
@@ -92,7 +90,7 @@ jobs:
       - name: Pull image from Amazon ECR and restart container
         run: |
           # Get the image URL from the deploy-ecr job's outputs
-          IMAGE_URL=${{ env.IMAGE_URL }}
+          IMAGE_URL=$(cat $GITHUB_STATE | grep "IMAGE_URL=" | cut -d= -f2)
 
           docker pull $IMAGE_URL
           docker stop concert-tdd && docker rm concert-tdd

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -57,28 +57,13 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
         run: |
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
-          # Output the image URL to the GitHub Actions environment
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
-
-          # Set the image URL as an output for other jobs
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
-      - name: Pull image from Amazon ECR and restart container
-        run: |
-          # Get the image URL from the deploy-ecr job's outputs
-          IMAGE_URL=${{ needs.deploy-ecr.outputs.image }}
-
-          docker pull $IMAGE_URL
-          docker stop concert-tdd && docker rm concert-tdd
-          docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped $IMAGE_URL
   deploy-ec2:
     needs: deploy-ecr
     name: Deploy to EC2
@@ -97,9 +82,11 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Pull image from Amazon ECR and restart container
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           # Get the image URL from the deploy-ecr job's outputs
-          IMAGE_URL=$(cat $GITHUB_STATE | grep "IMAGE_URL=" | cut -d= -f2)
+          IMAGE_URL=$ECR_REGISTRY/ECR_REPOSITORY:latest
 
           docker pull $IMAGE_URL
           docker stop concert-tdd && docker rm concert-tdd

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -64,8 +64,12 @@ jobs:
           # be deployed to ECS.
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+          # Output the image URL to the GitHub Actions environment
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
+
+          # Set the image URL as an output for other jobs
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
   deploy-ec2:
     needs: deploy-ecr
     name: Deploy to EC2
@@ -85,6 +89,9 @@ jobs:
 
       - name: Pull image from Amazon ECR and restart container
         run: |
-          docker pull ${{ needs.deploy-ecr.steps.build-image.outputs.image }}
+          # Get the image URL from the deploy-ecr job's outputs
+          IMAGE_URL=${{ needs.deploy-ecr.outputs.image }}
+
+          docker pull $IMAGE_URL
           docker stop concert-tdd && docker rm concert-tdd
-          docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped ${{ needs.deploy-ecr.steps.build-image.outputs.image }}
+          docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped $IMAGE_URL

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -85,6 +85,6 @@ jobs:
 
       - name: Pull image from Amazon ECR and restart container
         run: |
-          docker pull ${{ steps.build-image.outputs.image }}
+          docker pull ${{ needs.deploy-ecr.steps.build-image.outputs.image }}
           docker stop concert-tdd && docker rm concert-tdd
-          docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped ${{ steps.build-image.outputs.image }}
+          docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped ${{ needs.deploy-ecr.steps.build-image.outputs.image }}

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -1,0 +1,90 @@
+name: Deploy to Amazon ECS
+
+on:
+  push:
+    branches: ['beom/infra_refactor']
+
+env:
+  AWS_REGION: ap-northeast-2 # set this to your preferred AWS region, e.g. us-west-1
+  ECR_REPOSITORY: concert-tdd-repository # set this to your Amazon ECR repository name
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout V4
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Create .env.production file
+        run: |
+          echo "DB_HOST=${{ secrets.DB_HOST }}" >> .env.production
+          echo "DB_PORT=${{ secrets.DB_PORT }}" >> .env.production
+          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env.production
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env.production
+          echo "DB_DATABASE=${{ secrets.DB_DATABASE }}" >> .env.production
+          echo "REDIS_HOST=${{ secrets.REDIS_HOST }}" >> .env.production
+          echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> .env.production
+          echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env.production
+          echo "AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}" >> .env.production
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .env.production
+          echo "APP_PORT=${{ vars.APP_PORT }}" >> .env.production
+          echo "CLOUDWATCH_GROUP=${{ vars.CLOUDWATCH_GROUP }}" >> .env.production
+          echo "CLOUDWATCH_REGION=${{ vars.CLOUDWATCH_REGION }}" >> .env.production
+          echo "CLOUDWATCH_STREAM_ERROR=${{ vars.CLOUDWATCH_STREAM_ERROR }}" >> .env.production
+          echo "CLOUDWATCH_STREAM_INFO=${{ vars.CLOUDWATCH_STREAM_INFO }}" >> .env.production
+          echo "DB_SYNCHRONIZE=${{ vars.DB_SYNCHRONIZE }}" >> .env.production
+          echo "MAX_TASKS=${{ vars.MAX_TASKS }}" >> .env.production
+          echo "TASK_EXPIRED_SECONDS=${{ vars.TASK_EXPIRED_SECONDS }}" >> .env.production
+          echo "TURN_OFF_WAITING_GUARD=${{ vars.TURN_OFF_WAITING_GUARD }}" >> .env.production
+          echo "DNS_ADDRESS=${{ vars.DNS_ADDRESS }}" >> .env.production
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # Build a docker container and
+          # push it to ECR so that it can
+          # be deployed to ECS.
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          
+  deploy:
+    needs: build
+    name: CD
+    runs-on: [self-hosted, concert-tdd-runner]
+    
+    steps:
+    - name: Configure AWS credentials 
+      uses: aws-actions/configure-aws-credentials@v1 
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ap-northeast-2
+
+    - name: Login to Amazon ECR 
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Pull image from Amazon ECR and restart container
+      run: |
+        docker pull ${{ steps.build-image.outputs.image }}
+        docker stop concert-tdd && docker rm concert-tdd
+        docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped ${{ steps.build-image.outputs.image }}

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  deploy-ecr:
     name: Deploy
     runs-on: ubuntu-latest
     environment: production
@@ -65,26 +65,26 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
-          
-  deploy:
+
+  deploy-ec2:
     needs: build
     name: CD
     runs-on: [self-hosted, concert-tdd-runner]
-    
+
     steps:
-    - name: Configure AWS credentials 
-      uses: aws-actions/configure-aws-credentials@v1 
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ap-northeast-2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
 
-    - name: Login to Amazon ECR 
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Pull image from Amazon ECR and restart container
-      run: |
-        docker pull ${{ steps.build-image.outputs.image }}
-        docker stop concert-tdd && docker rm concert-tdd
-        docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped ${{ steps.build-image.outputs.image }}
+      - name: Pull image from Amazon ECR and restart container
+        run: |
+          docker pull ${{ steps.build-image.outputs.image }}
+          docker stop concert-tdd && docker rm concert-tdd
+          docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped ${{ steps.build-image.outputs.image }}

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy-ecr:
     name: Deploy to ECR
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, concert-tdd-runner]
     environment: production
 
     steps:
@@ -65,11 +65,20 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-          # Save the image URL to the GitHub Actions state file
-          echo "IMAGE_URL=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_STATE
+          # Output the image URL to the GitHub Actions environment
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
 
           # Set the image URL as an output for other jobs
-          echo "IMAGE_URL=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Pull image from Amazon ECR and restart container
+        run: |
+          # Get the image URL from the deploy-ecr job's outputs
+          IMAGE_URL=${{ needs.deploy-ecr.outputs.image }}
+
+          docker pull $IMAGE_URL
+          docker stop concert-tdd && docker rm concert-tdd
+          docker run -d --name concert-tdd -p 80:3000 --restart unless-stopped $IMAGE_URL
   deploy-ec2:
     needs: deploy-ecr
     name: Deploy to EC2

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-ecr:
-    name: Deploy
+    name: Deploy to ECR
     runs-on: ubuntu-latest
     environment: production
 
@@ -67,8 +67,8 @@ jobs:
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deploy-ec2:
-    needs: build
-    name: CD
+    needs: deploy-ecr
+    name: Deploy to EC2
     runs-on: [self-hosted, concert-tdd-runner]
 
     steps:

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -65,11 +65,8 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-          # Output the image URL to the GitHub Actions environment
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-          # Set the image URL as an output for other jobs
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
   deploy-ec2:
     needs: deploy-ecr
     name: Deploy to EC2

--- a/.github/workflows/ec2.yaml
+++ b/.github/workflows/ec2.yaml
@@ -86,7 +86,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           # Get the image URL from the deploy-ecr job's outputs
-          IMAGE_URL=$ECR_REGISTRY/ECR_REPOSITORY:latest
+          IMAGE_URL=$ECR_REGISTRY/$ECR_REPOSITORY:latest
 
           docker pull $IMAGE_URL
           docker stop concert-tdd && docker rm concert-tdd

--- a/.github/workflows/ecs.yaml
+++ b/.github/workflows/ecs.yaml
@@ -1,29 +1,3 @@
-# This workflow will build and push a new container image to Amazon ECR,
-# and then will deploy a new task definition to Amazon ECS, when there is a push to the "prod" branch.
-#
-# To use this workflow, you will need to complete the following set-up steps:
-#
-# 1. Create an ECR repository to store your images.
-#    For example: `aws ecr create-repository --repository-name my-ecr-repo --region us-east-2`.
-#    Replace the value of the `ECR_REPOSITORY` environment variable in the workflow below with your repository's name.
-#    Replace the value of the `AWS_REGION` environment variable in the workflow below with your repository's region.
-#
-# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
-#    For example, follow the Getting Started guide on the ECS console:
-#      https://us-east-2.console.aws.amazon.com/ecs/home?region=us-east-2#/firstRun
-#    Replace the value of the `ECS_SERVICE` environment variable in the workflow below with the name you set for the Amazon ECS service.
-#    Replace the value of the `ECS_CLUSTER` environment variable in the workflow below with the name you set for the cluster.
-#
-# 3. Store your ECS task definition as a JSON file in your repository.
-#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
-#    Replace the value of the `ECS_TASK_DEFINITION` environment variable in the workflow below with the path to the JSON file.
-#    Replace the value of the `CONTAINER_NAME` environment variable in the workflow below with the name of the container
-#    in the `containerDefinitions` section of the task definition.
-#
-# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
-#    and best practices on handling the access key credentials.
-
 name: Deploy to Amazon ECS
 
 on:
@@ -100,18 +74,18 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-      # - name: Fill in the new image ID in the Amazon ECS task definition
-      #   id: task-def
-      #   uses: aws-actions/amazon-ecs-render-task-definition@v1
-      #   with:
-      #     task-definition: ${{ env.ECS_TASK_DEFINITION }}
-      #     container-name: ${{ env.CONTAINER_NAME }}
-      #     image: ${{ steps.build-image.outputs.image }}
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ${{ env.ECS_TASK_DEFINITION }}
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.build-image.outputs.image }}
 
-      # - name: Deploy Amazon ECS task definition
-      #   uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      #   with:
-      #     task-definition: ${{ steps.task-def.outputs.task-definition }}
-      #     service: ${{ env.ECS_SERVICE }}
-      #     cluster: ${{ env.ECS_CLUSTER }}
-      #     wait-for-service-stability: true
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/.github/workflows/ecs.yaml
+++ b/.github/workflows/ecs.yaml
@@ -28,11 +28,11 @@ name: Deploy to Amazon ECS
 
 on:
   push:
-    branches: ['prod']
+    branches: ['beom/infra_refactor']
 
 env:
   AWS_REGION: ap-northeast-2 # set this to your preferred AWS region, e.g. us-west-1
-  ECR_REPOSITORY: concert-tdd # set this to your Amazon ECR repository name
+  ECR_REPOSITORY: concert-tdd-repository # set this to your Amazon ECR repository name
   ECS_SERVICE: concert-tdd-service # set this to your Amazon ECS service name
   ECS_CLUSTER: concert-tdd # set this to your Amazon ECS cluster name
   ECS_TASK_DEFINITION:
@@ -100,18 +100,18 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: ${{ env.ECS_TASK_DEFINITION }}
-          container-name: ${{ env.CONTAINER_NAME }}
-          image: ${{ steps.build-image.outputs.image }}
+      # - name: Fill in the new image ID in the Amazon ECS task definition
+      #   id: task-def
+      #   uses: aws-actions/amazon-ecs-render-task-definition@v1
+      #   with:
+      #     task-definition: ${{ env.ECS_TASK_DEFINITION }}
+      #     container-name: ${{ env.CONTAINER_NAME }}
+      #     image: ${{ steps.build-image.outputs.image }}
 
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE }}
-          cluster: ${{ env.ECS_CLUSTER }}
-          wait-for-service-stability: true
+      # - name: Deploy Amazon ECS task definition
+      #   uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      #   with:
+      #     task-definition: ${{ steps.task-def.outputs.task-definition }}
+      #     service: ${{ env.ECS_SERVICE }}
+      #     cluster: ${{ env.ECS_CLUSTER }}
+      #     wait-for-service-stability: true

--- a/.github/workflows/ecs.yaml
+++ b/.github/workflows/ecs.yaml
@@ -28,7 +28,7 @@ name: Deploy to Amazon ECS
 
 on:
   push:
-    branches: ['beom/infra_refactor']
+    branches: ['prod']
 
 env:
   AWS_REGION: ap-northeast-2 # set this to your preferred AWS region, e.g. us-west-1


### PR DESCRIPTION
- ECS-Fargate 조합으로 Elastic cache에 접속하려면 aws terminal에서 하던지 접속용 ec2를 따로 파야된다고 하더라구요.

- EC2 중심으로 해야 유연하게 이것저것 해볼 수 있을 것 같아서 ECS -> EC2로 교체했습니다.
http://ec2-15-165-199-211.ap-northeast-2.compute.amazonaws.com/docs (비용때문에 일단 EC2는 중지시켜놓을게요)

- EC2 배포에 맞게 Github action도 수정했습니다
  => Github에서 ubuntu-latest 환경에서 도커 빌드 => ECR 업로드
  => 띄워져 있는 EC2에 깃헙액션 설치해서 self-hosted runner로 지정하고 ECR에서 이미지 풀 => 컨테이너 런
![image](https://github.com/team-sparta-11/tdd/assets/33365719/9fceb41b-aaa3-484d-a483-fb92184ee429)

- 다행히 elastic cache 접속 가능합니다 ㅎ
![image](https://github.com/team-sparta-11/tdd/assets/33365719/afb0be58-d206-4448-863b-e43bc5f20d49)

이번주 토욜전까지 클라우드와치, 슬랙쪽 추가적으로 작업해볼 예정입니다
